### PR TITLE
Add time example

### DIFF
--- a/time.hs
+++ b/time.hs
@@ -1,0 +1,40 @@
+import qualified Data.Time as Time
+
+main = do
+
+  now <- Time.getZonedTime
+  print now
+
+  let then_ = Time.ZonedTime
+        (Time.LocalTime
+          (Time.fromGregorian 2009 11 17)
+          (Time.TimeOfDay 20 34 58.651387237))
+        Time.utc
+  print then_
+
+  let (year, month, day) = Time.toGregorian
+        (Time.localDay (Time.zonedTimeToLocalTime then_))
+  print year
+  print month
+  print day
+  print (Time.todHour (Time.localTimeOfDay (Time.zonedTimeToLocalTime then_)))
+  print (Time.todMin (Time.localTimeOfDay (Time.zonedTimeToLocalTime then_)))
+  print (Time.todSec (Time.localTimeOfDay (Time.zonedTimeToLocalTime then_)))
+  print (Time.zonedTimeZone then_)
+
+  print (Time.dayOfWeek (Time.localDay (Time.zonedTimeToLocalTime then_)))
+
+  print (Time.zonedTimeToUTC then_ < Time.zonedTimeToUTC now)
+  print (Time.zonedTimeToUTC then_ > Time.zonedTimeToUTC now)
+  print (Time.zonedTimeToUTC then_ == Time.zonedTimeToUTC now)
+
+  let diff = Time.diffUTCTime
+        (Time.zonedTimeToUTC now) (Time.zonedTimeToUTC then_)
+  print diff
+
+  print (Time.nominalDiffTimeToSeconds diff / 60 / 60)
+  print (Time.nominalDiffTimeToSeconds diff / 60)
+  print (Time.nominalDiffTimeToSeconds diff)
+
+  print (Time.addUTCTime diff (Time.zonedTimeToUTC then_))
+  print (Time.addUTCTime (-diff) (Time.zonedTimeToUTC then_))

--- a/time.hs
+++ b/time.hs
@@ -1,40 +1,26 @@
 import qualified Data.Time as Time
+import qualified Data.Time.Clock.POSIX as POSIX
 
 main = do
 
-  now <- Time.getZonedTime
+  now <- Time.getCurrentTime
   print now
 
-  let then_ = Time.ZonedTime
-        (Time.LocalTime
-          (Time.fromGregorian 2009 11 17)
-          (Time.TimeOfDay 20 34 58.651387237))
-        Time.utc
-  print then_
+  let render = Time.formatTime Time.defaultTimeLocale
+  putStrLn (render "%Y-%m-%d %H:%M:%S" now)
 
-  let (year, month, day) = Time.toGregorian
-        (Time.localDay (Time.zonedTimeToLocalTime then_))
-  print year
-  print month
-  print day
-  print (Time.todHour (Time.localTimeOfDay (Time.zonedTimeToLocalTime then_)))
-  print (Time.todMin (Time.localTimeOfDay (Time.zonedTimeToLocalTime then_)))
-  print (Time.todSec (Time.localTimeOfDay (Time.zonedTimeToLocalTime then_)))
-  print (Time.zonedTimeZone then_)
+  let soon = Time.addUTCTime 15 now
+  print soon
 
-  print (Time.dayOfWeek (Time.localDay (Time.zonedTimeToLocalTime then_)))
+  let parse = Time.parseTimeM False Time.defaultTimeLocale
+  y2038 <- parse "%Y-%m-%d %H:%M:%S" "2038-01-19 03:14:07"
+  print (y2038 :: Time.UTCTime)
 
-  print (Time.zonedTimeToUTC then_ < Time.zonedTimeToUTC now)
-  print (Time.zonedTimeToUTC then_ > Time.zonedTimeToUTC now)
-  print (Time.zonedTimeToUTC then_ == Time.zonedTimeToUTC now)
+  let delta = Time.diffUTCTime y2038 now
+  print delta
 
-  let diff = Time.diffUTCTime
-        (Time.zonedTimeToUTC now) (Time.zonedTimeToUTC then_)
-  print diff
+  posix <- POSIX.getPOSIXTime
+  print posix
 
-  print (Time.nominalDiffTimeToSeconds diff / 60 / 60)
-  print (Time.nominalDiffTimeToSeconds diff / 60)
-  print (Time.nominalDiffTimeToSeconds diff)
-
-  print (Time.addUTCTime diff (Time.zonedTimeToUTC then_))
-  print (Time.addUTCTime (-diff) (Time.zonedTimeToUTC then_))
+  print (POSIX.utcTimeToPOSIXSeconds now)
+  print (POSIX.posixSecondsToUTCTime posix)

--- a/time.hs
+++ b/time.hs
@@ -11,6 +11,7 @@ main = do
 
   let soon = Time.addUTCTime 15 now
   print soon
+  print (now < soon)
 
   let parse = Time.parseTimeM False Time.defaultTimeLocale
   y2038 <- parse "%Y-%m-%d %H:%M:%S" "2038-01-19 03:14:07"


### PR DESCRIPTION
I'm opening this PR more for discussion than anything else. Ostensibly it addresses #5, but the code as written doesn't provide any of the suggested examples. 

I tried to perform a more-or-less direct translation of [Go by Example: Time](https://gobyexample.com/time). Along the way I noticed several things:

- Haskell's `time` library is not looking very good by comparison to Go's `time` package. For example, in Haskell creating a "time" (really a `ZonedTime`) takes 3 constructors, one function call, and one value. In Go it's a single method.

- I used `ZonedTime` because it matched Go, but I think most "real" Haskell code uses `UTCTime`. Pretty much everything I write does, at least. 

- Go by Example has another entire page on formatting: https://gobyexample.com/time-formatting-parsing

- Getting particular parts of the time are surprisingly challenging. For example, getting the year requires throwing away the time zone, then focusing on the day piece, then destructuring a 3-tuple. That's especially awkward because combinators for 3-tuples (like `fst3`) aren't super common. (On the other hand, I frequently work with times and almost never need to get just the year part of a time.) 

- Splitting apart seconds into the whole number part and the fractional part is challenging. Getting the whole number part is easy enough: `truncate`. But getting the fractional part would take some puzzling. Something like `s - fromIntegral (truncate s)` comes to mind, but that's gross.

- `ZonedTime` values can't be compared directly. I think the `time` library does this to make you choose between comparing them as local times or as absolute times. Either way, it makes this example super annoying. (As I said before, I almost always use `UTCTime`.) 

- The `time` library doesn't provide any handy conversion functions, like for getting the length of a duration in hours. It's not hard to do the conversion manually, but it's not as nice as having a function for it. 

In short, I feel like the Go example doesn't fit well into Haskell. Maybe things would be better with a different library. I think the Go example is a bit weird though, and shows off things I don't often do with time libraries. 

I think the Haskell Phrasebook would be better off using some different examples. I'll spend some time tomorrow coming up with some more typical Haskell `time` usage. 