### PR TITLE
Add examples for mutable vectors

### DIFF
--- a/mutable-vectors.hs
+++ b/mutable-vectors.hs
@@ -1,0 +1,54 @@
+import           Control.Monad.ST
+import qualified Data.Vector         as V
+import qualified Data.Vector.Mutable as MV
+
+makeVec :: V.Vector Double
+makeVec =
+  runST $ do
+    v <- MV.replicate 3 0
+    MV.write v 1 100
+    V.freeze v
+
+makeVec' :: IO (V.Vector Double)
+makeVec' = do
+  v <- MV.replicate 3 0
+  MV.write v 1 100
+  V.freeze v
+
+main = do
+  mutableVector <- MV.replicate 5 "Default value"
+  item <- MV.read mutableVector 0
+  print ("Item at index 0 of mutableVector: " ++ item)
+  -- ^ Create and fill a mutable vector
+
+  let immutableVector = V.replicate 5 "Default value"
+  mutableVector2 <- V.thaw immutableVector
+  item <- MV.read mutableVector2 0
+  print ("Item at index 0 of mutableVector2: " ++ item)
+  -- ^ Create and fill a non-mutable vector, then create mutable
+  -- version from it
+
+  MV.write mutableVector2 0 "New value"
+  item <- MV.read mutableVector2 0
+  print ("New item at index 0 mutableVector2: " ++ item)
+  -- ^ Set value at index (mutate in place)
+
+  frozen <- V.freeze mutableVector2
+  let frozen' = V.map (const "Another value") frozen
+  print ("Contents of frozen': " ++ show frozen')
+  -- ^ Freeze a mutable vector
+
+  V.copy mutableVector2 frozen'
+  item <- MV.read mutableVector2 0
+  print ("New item at index 0 of mutableVector2: " ++ item)
+  -- ^ Copy an immutable vector into a mutable one
+
+  print (V.modify (\v -> MV.write v 0 100) (V.replicate 5 0))
+  -- ^ Perform a destructive update on an **immutable vector**
+  
+  print makeVec
+  vec <- makeVec'
+  print vec
+  -- ^ Showcase that Mutable Vector can work with both IO but also
+  -- ST and that ST has the cool advantage that it doesn't "infect'
+  -- other functions like IO does.


### PR DESCRIPTION
This is an example for #6 

As outlined in the issue I first go through a couple of commonly used functions from `Data.Vector.Mutable`, showing how to create, read and write MVs (including how to create them from an immutable vector).

Since it's hard to really separate MV from just V I also wanted to show that `Data.Vector.modify` can actually update an immutable vector in place.

Last but not least I included some lines to show that MV works with IO and also ST. This is a bit more advanced, but I think it's still important to know. MV isn't something you often reach for (I used it once to speed up an Advent of Code puzzle). So often you'll start with just a vector and then later on add mutability for speed. In those cases it can be really nice knowing that you can perform some mutations in a separate functions that just takes a plain old vector and gives you a plain old vector back. No `IO` spreading through your code.

The current example simple shows how to create an immutable vector, write to it, but then return an immutable, frozen vector from it. I could modify it to show the "take vec, mutate, return vec" but that's adding some more complexity to it of course.