### PR TITLE
Add records with optics example

### DIFF
--- a/records-with-optics.hs
+++ b/records-with-optics.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+import           Optics
+
+data Address = Address
+  { _city    :: String
+  , _country :: String
+  } deriving (Show)
+
+makeLenses ''Address
+
+data Person = Person
+  { _name    :: String
+  , _age     :: Int
+  , _address :: Address
+  } deriving (Show)
+
+makeLenses ''Person
+
+main = do
+  let alice =
+        Person
+          {_name = "Alice", _age = 30, _address = Address "Faketown" "Fakeland"}
+  print alice
+  print (set age 40 alice)
+  print (over age (+ 1) alice)
+  print (view age alice)
+  print (view (address % city) alice)
+  print (set (address % city) "Fakeville" alice)


### PR DESCRIPTION
For #9 

Shows how to use `set`, `over`, and `view` and also has a little example for how to compose simple lenses. I think adding the `%` example makes sense since nested record updates aren't so rare and I think this hints at the many possibilities that lens composition offers without introducing anything too complex.

The `TemplateHaskell` part could be replaced by manually writing some lenses but considering how common it is to use TH here I'd keep TH.